### PR TITLE
Make travis-ci.org route your builds to the Erlang worker (least busy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: erlang
 script: "runghc -isrc -itests tests/CountVonCount/TestSuite.hs --plain"
 before_install:
     - "cd count-von-count"


### PR DESCRIPTION
It is not very cool to use hardware donated for Ruby projects to build Haskell. At least use something
that is less busy.
