### PR TITLE
Use (not yet documented or announced) Haskell support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
-language: erlang
+language: haskell
 script: "runghc -isrc -itests tests/CountVonCount/TestSuite.hs --plain"
 before_install:
     - "cd count-von-count"
-    - "sudo add-apt-repository ppa:gspreemann/haskell"
-    - "sudo apt-get update"
-    - "sudo apt-get install -y ghc cabal-install"
     - "cabal update"
     - "cabal install"
     - "cabal install test-framework-hunit"


### PR DESCRIPTION
We provide Haskell Platform 2011.04 (GHC 7.0, cabal, etc). Please keep this secret for a few days.
