### PR TITLE
Ready: Fix padding stuff on all pages (for mobile)

### DIFF
--- a/boxxy/content/afterparty.html
+++ b/boxxy/content/afterparty.html
@@ -1,12 +1,10 @@
-<div class="schedule row">
-    <div class="thirteen columns offset-by-five">
-        <table>
-          <tr><th>21u00</th><td>Eindceremonie met fakkel- en vlaggentocht,<br />begeleid door de Gentse Studentenfanfare</td></tr>
-          <tr><th>21u15</th><td>Bart Ricardo</td></tr>
-          <tr><th>22u45</th><td>Bekendmaking winnaars 12urenloop en prijsuitreiking</td></tr>
-          <tr><th>23u00</th><td>Winnaar DJ-contest</td></tr>
-          <tr><th>23u30</th><td>DJ Natick</td></tr>
-          <tr><th>01u00</th><td>Chillout mix by Fou Concept</td></tr>
-        </table>
-    </div>
+<div class="sixteen columns">
+    <table class="schedule">
+      <tr><th>21u00</th><td>Eindceremonie met fakkel- en vlaggentocht,<br />begeleid door de Gentse Studentenfanfare</td></tr>
+      <tr><th>21u15</th><td>Bart Ricardo</td></tr>
+      <tr><th>22u45</th><td>Bekendmaking winnaars 12urenloop en prijsuitreiking</td></tr>
+      <tr><th>23u00</th><td>Winnaar DJ-contest</td></tr>
+      <tr><th>23u30</th><td>DJ Natick</td></tr>
+      <tr><th>01u00</th><td>Chillout mix by Fou Concept</td></tr>
+    </table>
 </div>

--- a/boxxy/content/dj-contest.html
+++ b/boxxy/content/dj-contest.html
@@ -1,22 +1,25 @@
-<div class="schedule row">
-    <div class="eleven columns offset-by-six">
-        <table>
-          <tr><th>17u15</th><td>C-Bass</td><td>(1)</td></tr>
-          <tr><th>17u55</th><td>Miss Charlie</td><td>(2)</td></tr>
-          <tr><th>18u35</th><td>FREESTYLE</td><td>(3)</td></tr>
-          <tr><th>19u15</th><td>FOCVS</td><td>(4)</td></tr>
-          <tr><th>19u55</th><td>Audiowave</td><td>(5)</td></tr>
-        </table>
-    </div>
+<div class="sixteen columns">
+    <table class="schedule">
+      <tr><th>17u15</th><td>C-Bass</td><td>(1)</td></tr>
+      <tr><th>17u55</th><td>Miss Charlie</td><td>(2)</td></tr>
+      <tr><th>18u35</th><td>FREESTYLE</td><td>(3)</td></tr>
+      <tr><th>19u15</th><td>FOCVS</td><td>(4)</td></tr>
+      <tr><th>19u55</th><td>Audiowave</td><td>(5)</td></tr>
+    </table>
 </div>
 
+<div class="sixteen columns">
 <h2>Stemmen</h2>
-<div style="text-align: center;">
-    <p>Op de dag zelf kan je vanaf 17u15 voor je favoriete DJ stemmen door <br /><strong>HOT &lt;nummer&gt;</strong> of
-    <strong>NOT &lt;nummer&gt;</strong> te sms'en naar 0478 012 970.<br />
+  <div style="text-align: center">
+    <p>
+      Op de dag zelf kan je vanaf 17u15 voor je favoriete DJ stemmen door <br />
+      <strong>HOT &lt;nummer&gt;</strong> of
+      <strong>NOT &lt;nummer&gt;</strong> te sms'en naar 0478 012 970.
     </p>
     <!-- <p>SMS <strong>HOT nummer</strong> of <strong>NOT nummer</strong> naar 0478 012 970. <br /> -->
     <p>
-    Wanneer een DJ speelt, kan je gewoon <strong>HOT</strong> of <strong>NOT</strong> sms'en<br />om voor die DJ te
-    stemmen.</p>
+      Wanneer een DJ speelt, kan je gewoon <strong>HOT</strong> of <strong>NOT</strong> sms'en<br />
+      om voor die DJ te stemmen.
+    </p>
+  </div>
 </div>

--- a/boxxy/public/css/timeline.css
+++ b/boxxy/public/css/timeline.css
@@ -1,10 +1,10 @@
 @media only screen and (max-width: 767px) {
-  .container {
+  .timeline.container {
     width: 100%;
   }
 }
 @media only screen and (max-width: 479px) {
-  .container {
+  .timeline.container {
     width: 100%;
   }
 }

--- a/boxxy/views/application.ejs
+++ b/boxxy/views/application.ejs
@@ -17,8 +17,8 @@
         </script>
 
         <link rel="stylesheet" type="text/css" href="/css/base.css">
-        <link rel="stylesheet" type="text/css" href="/css/layout.css">
         <link rel="stylesheet" type="text/css" href="/css/skeleton.css">
+        <link rel="stylesheet" type="text/css" href="/css/layout.css">
         <link rel="stylesheet" type="text/css" href="/css/timeline.css">
     </head>
 <body>
@@ -52,9 +52,9 @@
 		</select>
 	</nav>
 
-    <div class="container <%= (!!locals.container) ? container: '' %>">
-    <h2><%= title %></h2>
-	<%- content %>
+    <div class="container <%= (!!locals.container) ? container : '' %>">
+      <h2><%= title %></h2>
+      <%- content %>
     </div>
 
     <div class="sixteen columns">


### PR DESCRIPTION
This was an interesting one: timeline.css overwrote all `.container` to be of `100%` width, negating the default width given for different viewports. This was quite OK for the timeline but messed up the padding (which actually wasn't padding but just a centered div, a bit smaller than the viewport) for other pages. I only applied the 100% container width for the timeline page now.

Also contains some CSS fixes (schedule tables are auto centered, so we can just use a width of `sixteen columns`).

Screenshots from this branch:

![screen shot 2016-04-13 at 23 40 11](https://cloud.githubusercontent.com/assets/915130/14510327/3b2d2f9e-01d1-11e6-9a35-b0a045c376cd.png)

![screen shot 2016-04-13 at 23 40 23](https://cloud.githubusercontent.com/assets/915130/14510334/451a1454-01d1-11e6-9d5d-28fb7690b301.png)

![screen shot 2016-04-13 at 23 40 56](https://cloud.githubusercontent.com/assets/915130/14510343/4ecb518e-01d1-11e6-812c-4ff232d56a36.png)

![screen shot 2016-04-13 at 23 40 34](https://cloud.githubusercontent.com/assets/915130/14510347/5633afb6-01d1-11e6-8dcb-36aa8294f85e.png)

![screen shot 2016-04-13 at 23 41 06](https://cloud.githubusercontent.com/assets/915130/14510414/9aec64e0-01d1-11e6-9a4e-6566116d3431.png)

![screen shot 2016-04-13 at 23 40 45](https://cloud.githubusercontent.com/assets/915130/14510357/5d230f92-01d1-11e6-96b9-e97d52a72252.png)

![screen shot 2016-04-13 at 23 41 12](https://cloud.githubusercontent.com/assets/915130/14510368/647d5a2c-01d1-11e6-9ee3-47869483b49d.png)
